### PR TITLE
Release 5.1.0

### DIFF
--- a/cmd/mx-scenario-go/main.go
+++ b/cmd/mx-scenario-go/main.go
@@ -4,7 +4,7 @@ import (
 	scencli "github.com/multiversx/mx-chain-scenario-cli-go/cli"
 )
 
-const version = "5.0.0"
+const version = "5.1.0"
 
 func main() {
 	scencli.ScenariosCLI(version)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/multiversx/mx-chain-scenario-cli-go
 go 1.23
 
 require (
-	github.com/multiversx/mx-chain-scenario-go v1.6.0
+	github.com/multiversx/mx-chain-scenario-go v1.7.0
 	github.com/multiversx/mx-chain-vm-go v1.5.43
 	github.com/multiversx/mx-chain-vm-v1_4-go v1.4.99
 	github.com/urfave/cli/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IB
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-logger-go v1.1.0 h1:97x84A6L4RfCa6YOx1HpAFxZp1cf/WI0Qh112whgZNM=
 github.com/multiversx/mx-chain-logger-go v1.1.0/go.mod h1:K9XgiohLwOsNACETMNL0LItJMREuEvTH6NsoXWXWg7g=
-github.com/multiversx/mx-chain-scenario-go v1.6.0 h1:cwDFuS1pSc4YXnfiKKDTEb+QDY4fulPQaiRgIebnKxI=
-github.com/multiversx/mx-chain-scenario-go v1.6.0/go.mod h1:GrSYu1SnMvsIm9djUz1X13224HcvdY6Nb5KHNT3xZPA=
+github.com/multiversx/mx-chain-scenario-go v1.7.0 h1:7hEuvLPDZw2xA7YlzrjORxIK4lTTT34QL6O06JiotWE=
+github.com/multiversx/mx-chain-scenario-go v1.7.0/go.mod h1:GrSYu1SnMvsIm9djUz1X13224HcvdY6Nb5KHNT3xZPA=
 github.com/multiversx/mx-chain-storage-go v1.1.0 h1:M1Y9DqMrJ62s7Zw31+cyuqsnPIvlG4jLBJl5WzeZLe8=
 github.com/multiversx/mx-chain-storage-go v1.1.0/go.mod h1:o6Jm7cjfPmcc6XpyihYWrd6sx3sgqwurrunw3ZrfyxI=
 github.com/multiversx/mx-chain-vm-common-go v1.6.0 h1:M2zmf/ptEINciWxYCPLIkwOMTvvzWjELYYB+0MMQ5Gw=


### PR DESCRIPTION
Uses mx-scenario-go 1.7.0, which contains block time in milliseconds.